### PR TITLE
Add support for token-based authenticated rpc client

### DIFF
--- a/drwmutex.go
+++ b/drwmutex.go
@@ -39,6 +39,15 @@ type Granted struct {
 	uid    string
 }
 
+type LockArgs struct {
+	Token string
+	Name  string
+}
+
+func (l *LockArgs) SetToken(token string) {
+	l.Token = token
+}
+
 func NewDRWMutex(name string) *DRWMutex {
 	return &DRWMutex{
 		Name:  name,
@@ -149,9 +158,9 @@ func lock(clnts []RPC, locks *[]bool, uids *[]string, lockName string, isReadLoc
 			var status bool
 			var err error
 			if isReadLock {
-				err = c.Call("Dsync.RLock", lockName, &status)
+				err = c.Call("Dsync.RLock", &LockArgs{Name: lockName}, &status)
 			} else {
-				err = c.Call("Dsync.Lock", lockName, &status)
+				err = c.Call("Dsync.Lock", &LockArgs{Name: lockName}, &status)
 			}
 
 			locked, uid := false, ""
@@ -319,12 +328,12 @@ func sendRelease(c RPC, name, uid string, isReadLock bool) {
 			var err error
 			// TODO: Send UID to server
 			if isReadLock {
-				if err = c.Call("Dsync.RUnlock", name, &status); err == nil {
+				if err = c.Call("Dsync.RUnlock", &LockArgs{Name: name}, &status); err == nil {
 					// RUnlock delivered, exit out
 					return
 				}
 			} else {
-				if err = c.Call("Dsync.Unlock", name, &status); err == nil {
+				if err = c.Call("Dsync.Unlock", &LockArgs{Name: name}, &status); err == nil {
 					// Unlock delivered, exit out
 					return
 				}

--- a/rpc-client-impl_test.go
+++ b/rpc-client-impl_test.go
@@ -55,7 +55,7 @@ func (rpcClient *RPCClient) Close() error {
 }
 
 // Call makes a RPC call to the remote endpoint using the default codec, namely encoding/gob.
-func (rpcClient *RPCClient) Call(serviceMethod string, args interface{}, reply interface{}) error {
+func (rpcClient *RPCClient) Call(serviceMethod string, args TokenSetter, reply interface{}) error {
 	rpcClient.Lock()
 	defer rpcClient.Unlock()
 	// If the rpc.Client is nil, we attempt to (re)connect with the remote endpoint.

--- a/rpc-client-interface.go
+++ b/rpc-client-interface.go
@@ -16,7 +16,11 @@
 
 package dsync
 
+type TokenSetter interface {
+	SetToken(token string)
+}
+
 type RPC interface {
-	Call(serviceMethod string, args interface{}, reply interface{}) error
+	Call(serviceMethod string, args TokenSetter, reply interface{}) error
 	Close() error
 }


### PR DESCRIPTION
e.g, JWT based authentication using access-key, secret-key pair.
TokenSetter interface allows for re-negotiation of token, on disconnect.