### PR TITLE
Making DRWMutex compatible with sync.rwmutex again and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,226 @@
 dsync
 =====
 
-A distributed sync package.
+A distributed sync package for Go.
 
 Introduction
 ------------
  
-`dsync` is a package for doing distributed locks over a network of `n` nodes. It is designed with simplicity in mind and hence offers limited scalability (`n <= 16`). Each node will be connected to all other nodes and lock requests from any node will be broadcast to all connected nodes. A node will succeed in getting the lock if `n/2 + 1` nodes (including itself) respond positively. If the lock is acquired it can be held for some time and needs to be released afterwards. This will cause the release to be broadcast to all nodes after which the lock becomes available again.
+`dsync` is a package for doing distributed locks over a network of `n` nodes. It is designed with simplicity in mind and hence offers limited scalability (`n <= 16`). Each node will be connected to all other nodes and lock requests from any node will be broadcast to all connected nodes. A node will succeed in getting the lock if `n/2 + 1` nodes (whether or not including itself) respond positively. If the lock is acquired it can be held for as long as the client desired and needs to be released afterwards. This will cause the release to be broadcast to all nodes after which the lock becomes available again.
+
+Motivation
+----------
+
+This package was developed for the distributed server version of [Minio Object Storage](https://minio.io/). For this we needed a distributed locking mechanism for up to 16 servers that each would be running `minio server`. The locking mechanism itself should be a reader/writer mutual exclusion lock meaning that it can be held by a single writer or an arbitrary number of readers.
+
+For [minio](https://minio.io/) the distributed version is started as follows (for a 6-server system):
+
+```
+$ minio server server1/disk server2/disk server3/disk server4/disk server5/disk server6/disk 
+```
+ 
+_(note that the same identical command should be run on servers `server1` through to `server6`)_
 
 Design goals
 ------------
 
-* Simple design: by keeping the design simple, many tricky edge cases can be avoided.
-* No master node: there is no concept of a master node which, if this would be used and the master would be down, causes locking to come to a complete stop. (Unless you have a design with a slave node but this adds yet more complexity.)
-* Resilient: if one or more nodes go down, the other nodes should not be affected and can continue to acquire locks (provided not more than `n/2 - 1` nodes are down).
+* **Simple design**: by keeping the design simple, many tricky edge cases can be avoided.
+* **No master node**: there is no concept of a master node which, if this would be used and the master would be down, causes locking to come to a complete stop. (Unless you have a design with a slave node but this adds yet more complexity.)
+* **Resilient**: if one or more nodes go down, the other nodes should not be affected and can continue to acquire locks (provided not more than `n/2 - 1` nodes are down).
+* Drop-in replacement for `sync.RWMutex` and supports [`sync.Locker`](https://github.com/golang/go/blob/master/src/sync/mutex.go#L30) interface.
 * Automatically reconnect to (restarted) nodes.
-* Compatible with `sync/mutex` API.
-
 
 Restrictions
 ------------
 
 * Limited scalability: up to 16 nodes.
 * Fixed configuration: changes in the number and/or network names/IP addresses need a restart of all nodes in order to take effect.
-* If a down node comes up, it will not in any way (re)acquire any locks that it may have held.
-* Not designed for high performance applications such as key/value stores 
+* If a down node comes up, it will not try to (re)acquire any locks that it may have held.
+* Not designed for high performance applications such as key/value stores.
 
 Performance
 -----------
 
-* Lock requests (successful) should not take longer than 1ms (provided decent network connection of 1 Gbit or more between the nodes)
-* Support up to 4000 locks per node per second. 
-* Scale linearly with the number of locks. For the maximum size case of 16 nodes this means a maximum of 64K locks/sec (and 2048K lock request & release messages/sec)
-* Do not take more than (overall) 10% CPU usage
+* Support up to a total of 4000 locks/second for maximum size of 16 nodes (consuming 10% CPU usage per server) on moderately powerful server hardware.
+* Lock requests (successful) should not take longer than 1ms (provided decent network connection of 1 Gbit or more between the nodes).
+
+Usage
+-----
+
+### Exclusive lock 
+
+Here is a simple example showing how to protect a single resource (drop-in replacement for `sync.Mutex`):
+
+```
+import (
+    "github.com/minio/dsync"
+)
+
+func lockSameResource() {
+
+    // Create distributed mutex to protect resource 'test'
+	dm := dsync.NewDRWMutex("test")
+
+	dm.Lock()
+    log.Println("first lock granted")
+
+	// Release 1st lock after 5 seconds
+	go func() {
+		time.Sleep(5 * time.Second)
+		log.Println("first lock unlocked")
+		dm.Unlock()
+	}()
+
+    // Try to acquire lock again, will block until initial lock is released
+    log.Println("about to lock same resource again...")
+	dm.Lock()
+    log.Println("second lock granted")
+
+	time.Sleep(2 * time.Second)
+	dm.Unlock()
+}
+```
+
+which gives the following output:
+
+```
+2016/09/02 14:50:00 first lock granted
+2016/09/02 14:50:00 about to lock same resource again...
+2016/09/02 14:50:05 first lock unlocked
+2016/09/02 14:50:05 second lock granted
+```
+
+### Read locks
+
+DRWMutex also supports multiple simultaneous read locks as shown below (analogous to `sync.RWMutex`)
+
+```
+func twoReadLocksAndSingleWriteLock() {
+
+	drwm := dsync.NewDRWMutex("resource")
+
+	drwm.RLock()
+	log.Println("1st read lock acquired, waiting...")
+
+	drwm.RLock()
+	log.Println("2nd read lock acquired, waiting...")
+
+	go func() {
+		time.Sleep(1 * time.Second)
+		drwm.RUnlock()
+		log.Println("1st read lock released, waiting...")
+	}()
+
+	go func() {
+		time.Sleep(2 * time.Second)
+		drwm.RUnlock()
+		log.Println("2nd read lock released, waiting...")
+	}()
+
+	log.Println("Trying to acquire write lock, waiting...")
+	drwm.Lock()
+	log.Println("Write lock acquired, waiting...")
+	
+	time.Sleep(3 * time.Second)
+
+	drwm.Unlock()
+}
+```
+
+which gives the following output:
+
+```
+2016/09/02 15:05:20 1st read lock acquired, waiting...
+2016/09/02 15:05:20 2nd read lock acquired, waiting...
+2016/09/02 15:05:20 Trying to acquire write lock, waiting...
+2016/09/02 15:05:22 1st read lock released, waiting...
+2016/09/02 15:05:24 2nd read lock released, waiting...
+2016/09/02 15:05:24 Write lock acquired, waiting...
+```
+
+Dealing with Stale Locks
+------------------------
+
+Known deficiencies
+------------------
+
+Server side logic
+-----------------
+
+On the server side just the following logic needs to be added (barring some extra error checking):
+
+```
+const WriteLock = -1
+
+type lockServer struct {
+	mutex   sync.Mutex
+	lockMap map[string]int64 // Map of locks, with negative value indicating (exclusive) write lock
+	                         // and positive values indicating number of read locks
+}
+
+func (l *lockServer) Lock(args *LockArgs, reply *bool) error {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	if _, *reply = l.lockMap[args.Name]; !*reply {
+		l.lockMap[args.Name] = WriteLock // No locks held on the given name, so claim write lock
+	}
+	*reply = !*reply // Negate *reply to return true when lock is granted or false otherwise
+	return nil
+}
+
+func (l *lockServer) Unlock(args *LockArgs, reply *bool) error {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	var locksHeld int64
+	if locksHeld, *reply = l.lockMap[args.Name]; !*reply { // No lock is held on the given name
+		return fmt.Errorf("Unlock attempted on an unlocked entity: %s", args.Name) 
+	}
+	if *reply = locksHeld == WriteLock; !*reply { // Unless it is a write lock
+		return fmt.Errorf("Unlock attempted on a read locked entity: %s (%d read locks active)", args.Name, locksHeld)
+	}
+	delete(l.lockMap, args.Name) // Remove the write lock
+	return nil
+}
+```
+
+If you also want RLock()/RUnlock() functionality, then add this as well:
+
+```
+const ReadLock = 1
+
+func (l *lockServer) RLock(args *LockArgs, reply *bool) error {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	var locksHeld int64
+	if locksHeld, *reply = l.lockMap[args.Name]; !*reply {
+		l.lockMap[args.Name] = ReadLock // No locks held on the given name, so claim (first) read lock
+		*reply = true
+	} else {
+		if *reply = locksHeld != WriteLock; *reply { // Unless there is a write lock
+			l.lockMap[args.Name] = locksHeld + ReadLock // Grant another read lock
+		}
+	}
+	return nil
+}
+
+func (l *lockServer) RUnlock(args *LockArgs, reply *bool) error {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	var locksHeld int64
+	if locksHeld, *reply = l.lockMap[args.Name]; !*reply { // No lock is held on the given name
+		return fmt.Errorf("RUnlock attempted on an unlocked entity: %s", args.Name)
+	}
+	if *reply = locksHeld != WriteLock; !*reply { // A write-lock is held, cannot release a read lock
+		return fmt.Errorf("RUnlock attempted on a write locked entity: %s", args.Name)
+	}
+	if locksHeld > ReadLock {
+		l.lockMap[args.Name] = locksHeld - ReadLock // Remove one of the read locks held
+	} else {
+		delete(l.lockMap, args.Name) // Remove the (last) read lock
+	}
+	return nil
+}
+```
 
 Issues
 ------
@@ -43,32 +231,29 @@ Issues
 * When two nodes want to acquire the same lock, it is possible for both to just acquire `n` locks and there is no majority winner so both would fail (and presumably fail back to their clients?). This then requires a retry in order to acquire the lock at a later time.
 * What if late acquire response still comes in after lock has been obtained (quorum is in) and has already been released again. 
 
+
+
+Extensions / Other use cases
+----------------------------
+
+### Robustness vs Performance
+
+It is possible to trade some level of robustness with overall performance by not contacting each node for every Lock()/Unlock() cycle. In the normal case (example for `n = 16` nodes) a total of 32 RPC messages is sent and the lock is granted if at least a quorum of `n/2 + 1` nodes respond positively. When all nodes are functioning normally this would mean `n = 16` positive responses and, in fact, `n/2 - 1 = 7` responses over the (minimum) quorum of `n/2 + 1 = 9`. So you could say that this is some overkill, meaning that even if 6 nodes are down you still have an extra node over the quorum.
+
+For this case it is possible to reduce the number of nodes to be contacted to for example `12`. Instead of 32 RPC messages now 24 message will be sent which is 25% less. As the performance is mostly depending on the number of RPC messages sent, the total locks/second handled by all nodes would increase by 33% (given the same CPU load).
+
+You do however want to make sure that you have some sort of 'random' selection of which 12 out of the 16 nodes will participate in every lock. See [here](https://gist.github.com/fwessels/dbbafd537c13ec8f88b360b3a0091ac0) for some sample code that could help with this.
+
+### Scale beyond 16 nodes?
+
+Building on the previous example and depending on how resilient you want to be for outages of nodes, you can also go the other way, namely to increase the total number of nodes while keeping the number of nodes contacted per lock the same.
+
+For instance you could imagine a system of 32 nodes where only a quorom majority of `9` would be needed out of `12` nodes. Again this requires some sort of pseudo-random 'deterministic' selection of 12 nodes out of the total of 32 servers (same [example](https://gist.github.com/fwessels/dbbafd537c13ec8f88b360b3a0091ac0) as above). 
+
 Comparison to other techniques
 ------------------------------
 
-We are well aware that there are more sophisticated systems such as zookeeper, raft, etc but we found that for our limited use case this was adding too much complexity. So if `dsync` does not meet your requirements than you are probably better off using one of those systems.
-
-Performance
------------
-
-```
-benchmark                       old ns/op     new ns/op     delta
-BenchmarkMutexUncontended-8     4.22          1164018       +27583264.93%
-BenchmarkMutex-8                96.5          1223266       +1267533.16%
-BenchmarkMutexSlack-8           120           1192900       +993983.33%
-BenchmarkMutexWork-8            108           1239893       +1147949.07%
-BenchmarkMutexWorkSlack-8       142           1210129       +852103.52%
-BenchmarkMutexNoSpin-8          292           319479        +109310.62%
-BenchmarkMutexSpin-8            1163          1270066       +109106.02%
-```
-
-Usage
------
-
-Explain usage
-```
-```
-
+We are well aware that there are more sophisticated systems such as zookeeper, raft, etc. However we found that for our limited use case this was adding too much complexity. So if `dsync` does not meet your requirements than you are probably better off using one of those systems.
 
 License
 -------

--- a/drwmutex.go
+++ b/drwmutex.go
@@ -23,7 +23,6 @@ import (
 	"net"
 	"os"
 	"sync"
-	"sync/atomic"
 	"time"
 )
 
@@ -40,10 +39,10 @@ const DRWMutexAcquireTimeout = 25 * time.Millisecond // 25ms.
 
 // A DRWMutex is a distributed mutual exclusion lock.
 type DRWMutex struct {
-	Name      string
-	locks     []bool     // Array of nodes that granted a lock
-	m         sync.Mutex // Mutex to prevent multiple simultaneous locks from this node
-	singleUse int64      // Atomic counter to prevent more than one simultaneous call to either Lock() or RLock()
+	Name         string
+	writeLocks   []bool     // Array of nodes that granted a write lock
+	readersLocks [][]bool   // Array of array of nodes that granted reader locks
+	m            sync.Mutex // Mutex to prevent multiple simultaneous locks from this node
 }
 
 type Granted struct {
@@ -67,99 +66,58 @@ func (l *LockArgs) SetTimestamp(tstamp time.Time) {
 
 func NewDRWMutex(name string) *DRWMutex {
 	return &DRWMutex{
-		Name:  name,
-		locks: make([]bool, dnodeCount),
+		Name:       name,
+		writeLocks: make([]bool, dnodeCount),
 	}
 }
 
-// preventSimultaneousCalls double checks that no more than one call can be active for Lock() and RLock()
-func (dm *DRWMutex) preventSimultaneousCalls() {
-	// Do not allow more than one simultaneous call to Lock() or RLock()
-	if atomic.AddInt64(&dm.singleUse, 1) > 1 {
-		panic("More than one simultaneous Lock() or RLock() on same object is not allowed -- use different DRWMutex objects instead")
-	}
-}
+// Lock holds a write lock on dm.
+//
+// If the lock is already in use, the calling go routine
+// blocks until the mutex is available.
+func (dm *DRWMutex) Lock() {
 
-// releaseSingleUse decrease the atomic counter to zero again
-func (dm *DRWMutex) releaseSingleUse() {
-	if atomic.AddInt64(&dm.singleUse, -1) != 0 {
-		panic("Atomic counter should always be zero upon release")
-	}
+	isReadLock := false
+	dm.lockBlocking(isReadLock)
 }
 
 // RLock holds a read lock on dm.
 //
-// If the lock is already in use, the calling goroutine
-// blocks until the mutex is available.
+// If one or more read lock are already in use, it will grant another lock.
+// Otherwise the calling go routine blocks until the mutex is available.
 func (dm *DRWMutex) RLock() {
 
-	// Prevent more than one simultaneous call to Lock() or RLock()
-	dm.preventSimultaneousCalls()
-	defer dm.releaseSingleUse()
-
-	// Shield RLock() with local mutex in order to prevent more than
-	// one broadcast going out at the same time from this node
-	dm.m.Lock()
-	defer dm.m.Unlock()
-
-	runs, backOff := 1, 1
-
-	for {
-
-		// create temp arrays on stack
-		locks := make([]bool, dnodeCount)
-
-		// try to acquire the lock
-		isReadLock := true
-		success := lock(clnts, &locks, dm.Name, isReadLock)
-		if success {
-			// if success, copy array to object
-			copy(dm.locks, locks[:])
-			return
-		}
-
-		// We timed out on the previous lock, incrementally wait for a longer back-off time,
-		// and try again afterwards
-		time.Sleep(time.Duration(backOff) * time.Millisecond)
-
-		backOff += int(rand.Float64() * math.Pow(2, float64(runs)))
-		if backOff > 1024 {
-			backOff = backOff % 64
-
-			runs = 1 // reset runs
-		} else if runs < 10 {
-			runs++
-		}
-	}
+	isReadLock := true
+	dm.lockBlocking(isReadLock)
 }
 
-// Lock locks dm.
+// lockBlocking will acquire either a read or a write lock
 //
-// If the lock is already in use, the calling goroutine
-// blocks until the mutex is available.
-func (dm *DRWMutex) Lock() {
-
-	// Prevent more than one simultaneous call to Lock() or RLock()
-	dm.preventSimultaneousCalls()
-	defer dm.releaseSingleUse()
-
-	// Shield Lock() with local mutex in order to prevent more than
-	// one broadcast going out at the same time from this node
-	dm.m.Lock()
-	defer dm.m.Unlock()
+// The call will block until the lock is granted using a built-in
+// timing randomized back-off algorithm to try again until successful
+func (dm *DRWMutex) lockBlocking(isReadLock bool) {
 
 	runs, backOff := 1, 1
 
 	for {
-		// create temp arrays on stack
+		// create temp array on stack
 		locks := make([]bool, dnodeCount)
 
 		// try to acquire the lock
-		isReadLock := false
 		success := lock(clnts, &locks, dm.Name, isReadLock)
 		if success {
 			// if success, copy array to object
-			copy(dm.locks, locks[:])
+			if isReadLock {
+				dm.m.Lock()
+				defer dm.m.Unlock()
+				// append new array of bools at the end
+				dm.readersLocks = append(dm.readersLocks, make([]bool, dnodeCount))
+				// and copy stack array into last spot
+				copy(dm.readersLocks[len(dm.readersLocks)-1], locks[:])
+			} else {
+				copy(dm.writeLocks, locks[:])
+			}
+
 			return
 		}
 
@@ -297,52 +255,65 @@ func releaseAll(clnts []RPC, locks *[]bool, lockName string, isReadLock bool) {
 			(*locks)[lock] = false
 		}
 	}
+}
 
+// Unlock unlocks the write lock.
+//
+// It is a run-time error if dm is not locked on entry to Unlock.
+func (dm *DRWMutex) Unlock() {
+
+	// Check if minimally a single bool is set in the writeLocks array
+	lockFound := false
+	for _, b := range dm.writeLocks {
+		if b {
+			lockFound = true
+			break
+		}
+	}
+	if !lockFound {
+		panic("Trying to Unlock() while no Lock() is active")
+	}
+
+	isReadLock := false
+	unlock(&dm.writeLocks, dm.Name, isReadLock)
 }
 
 // RUnlock releases a read lock held on dm.
 //
 // It is a run-time error if dm is not locked on entry to RUnlock.
 func (dm *DRWMutex) RUnlock() {
-	// We don't panic like sync.Mutex, when an unlock is issued on an
-	// un-locked lock, since the lock rpc server may have restarted and
-	// "forgotten" about the lock.
 
-	// We don't need to wait until we have released all the locks (or the quorum)
-	// (a subsequent lock will retry automatically in case it would fail to get
-	//  quorum)
-	for index, c := range clnts {
+	// create temp array on stack
+	locks := make([]bool, dnodeCount)
 
-		if dm.locks[index] {
-			// broadcast lock release to all nodes the granted the lock
-			isReadLock := true
-			sendRelease(c, dm.Name, isReadLock)
-
-			dm.locks[index] = false
+	{
+		dm.m.Lock()
+		defer dm.m.Unlock()
+		if len(dm.readersLocks) == 0 {
+			panic("Trying to RUnlock() while no RLock() is active")
 		}
+		// Copy out first element to release it first (FIFO)
+		copy(locks, dm.readersLocks[0][:])
+		// Drop first element from array
+		dm.readersLocks = dm.readersLocks[1:]
 	}
+
+	isReadLock := true
+	unlock(&locks, dm.Name, isReadLock)
 }
 
-// Unlock unlocks dm.
-//
-// It is a run-time error if dm is not locked on entry to Unlock.
-func (dm *DRWMutex) Unlock() {
+func unlock(locks *[]bool, name string, isReadLock bool) {
 
-	// We don't panic like sync.Mutex, when an unlock is issued on an
-	// un-locked lock, since the lock rpc server may have restarted and
-	// "forgotten" about the lock.
+	// We don't need to synchronously wait until we have released all the locks (or the quorum)
+	// (a subsequent lock will retry automatically in case it would fail to get quorum)
 
-	// We don't need to wait until we have released all the locks (or the quorum)
-	// (a subsequent lock will retry automatically in case it would fail to get
-	//  quorum)
 	for index, c := range clnts {
 
-		if dm.locks[index] {
+		if (*locks)[index] {
 			// broadcast lock release to all nodes the granted the lock
-			isReadLock := false
-			sendRelease(c, dm.Name, isReadLock)
+			sendRelease(c, name, isReadLock)
 
-			dm.locks[index] = false
+			(*locks)[index] = false
 		}
 	}
 }
@@ -400,3 +371,14 @@ func sendRelease(c RPC, name string, isReadLock bool) {
 		}
 	}(c, name)
 }
+
+// DRLocker returns a sync.Locker interface that implements
+// the Lock and Unlock methods by calling drw.RLock and drw.RUnlock.
+func (dm *DRWMutex) DRLocker() sync.Locker {
+	return (*drlocker)(dm)
+}
+
+type drlocker DRWMutex
+
+func (dr *drlocker) Lock()   { (*DRWMutex)(dr).RLock() }
+func (dr *drlocker) Unlock() { (*DRWMutex)(dr).RUnlock() }

--- a/drwmutex_test.go
+++ b/drwmutex_test.go
@@ -16,43 +16,286 @@
 
 // GOMAXPROCS=10 go test
 
-package dsync
+package dsync_test
 
 import (
 	"fmt"
+	"runtime"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
+	. "github.com/minio/dsync"
 )
 
 func TestSimpleWriteLock(t *testing.T) {
 
-	drwm_r1 := NewDRWMutex("resource")
-	drwm_r2 := NewDRWMutex("resource")
-	drwm_w := NewDRWMutex("resource")
+	drwm := NewDRWMutex("resource")
 
-	drwm_r1.RLock()
-	fmt.Println("1st read lock acquired, waiting...")
+	drwm.RLock()
+	// fmt.Println("1st read lock acquired, waiting...")
 
-	drwm_r2.RLock()
-	fmt.Println("2nd read lock acquired, waiting...")
+	drwm.RLock()
+	// fmt.Println("2nd read lock acquired, waiting...")
 
 	go func() {
 		time.Sleep(1000 * time.Millisecond)
-		drwm_r1.RUnlock()
-		fmt.Println("1st read lock released, waiting...")
+		drwm.RUnlock()
+		// fmt.Println("1st read lock released, waiting...")
 	}()
 
 	go func() {
 		time.Sleep(2000 * time.Millisecond)
-		drwm_r2.RUnlock()
-		fmt.Println("2nd read lock released, waiting...")
+		drwm.RUnlock()
+		// fmt.Println("2nd read lock released, waiting...")
 	}()
 
-	fmt.Println("Trying to acquire write lock, waiting...")
-	drwm_w.Lock()
+	// fmt.Println("Trying to acquire write lock, waiting...")
+	drwm.Lock()
 
-	fmt.Println("Write lock acquired, waiting...")
+	// fmt.Println("Write lock acquired, waiting...")
 	time.Sleep(2500 * time.Millisecond)
 
-	drwm_w.Unlock()
+	drwm.Unlock()
+}
+
+// Test cases below are copied 1 to 1 from sync/rwmutex_test.go (adapted to use DRWMutex)
+
+// Borrowed from rwmutex_test.go
+func parallelReader(m *DRWMutex, clocked, cunlock, cdone chan bool) {
+	m.RLock()
+	clocked <- true
+	<-cunlock
+	m.RUnlock()
+	cdone <- true
+}
+
+// Borrowed from rwmutex_test.go
+func doTestParallelReaders(numReaders, gomaxprocs int) {
+	runtime.GOMAXPROCS(gomaxprocs)
+	m := NewDRWMutex("test-parallel")
+
+	clocked := make(chan bool)
+	cunlock := make(chan bool)
+	cdone := make(chan bool)
+	for i := 0; i < numReaders; i++ {
+		go parallelReader(m, clocked, cunlock, cdone)
+	}
+	// Wait for all parallel RLock()s to succeed.
+	for i := 0; i < numReaders; i++ {
+		<-clocked
+	}
+	for i := 0; i < numReaders; i++ {
+		cunlock <- true
+	}
+	// Wait for the goroutines to finish.
+	for i := 0; i < numReaders; i++ {
+		<-cdone
+	}
+}
+
+// Borrowed from rwmutex_test.go
+func TestParallelReaders(t *testing.T) {
+	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(-1))
+	doTestParallelReaders(1, 4)
+	doTestParallelReaders(3, 4)
+	doTestParallelReaders(4, 2)
+}
+
+// Borrowed from rwmutex_test.go
+func reader(rwm *DRWMutex, num_iterations int, activity *int32, cdone chan bool) {
+	for i := 0; i < num_iterations; i++ {
+		rwm.RLock()
+		n := atomic.AddInt32(activity, 1)
+		if n < 1 || n >= 10000 {
+			panic(fmt.Sprintf("wlock(%d)\n", n))
+		}
+		for i := 0; i < 100; i++ {
+		}
+		atomic.AddInt32(activity, -1)
+		rwm.RUnlock()
+	}
+	cdone <- true
+}
+
+// Borrowed from rwmutex_test.go
+func writer(rwm *DRWMutex, num_iterations int, activity *int32, cdone chan bool) {
+	for i := 0; i < num_iterations; i++ {
+		rwm.Lock()
+		n := atomic.AddInt32(activity, 10000)
+		if n != 10000 {
+			panic(fmt.Sprintf("wlock(%d)\n", n))
+		}
+		for i := 0; i < 100; i++ {
+		}
+		atomic.AddInt32(activity, -10000)
+		rwm.Unlock()
+	}
+	cdone <- true
+}
+
+// Borrowed from rwmutex_test.go
+func HammerRWMutex(gomaxprocs, numReaders, num_iterations int) {
+	runtime.GOMAXPROCS(gomaxprocs)
+	// Number of active readers + 10000 * number of active writers.
+	var activity int32
+	rwm := NewDRWMutex("test")
+	cdone := make(chan bool)
+	go writer(rwm, num_iterations, &activity, cdone)
+	var i int
+	for i = 0; i < numReaders/2; i++ {
+		go reader(rwm, num_iterations, &activity, cdone)
+	}
+	go writer(rwm, num_iterations, &activity, cdone)
+	for ; i < numReaders; i++ {
+		go reader(rwm, num_iterations, &activity, cdone)
+	}
+	// Wait for the 2 writers and all readers to finish.
+	for i := 0; i < 2+numReaders; i++ {
+		<-cdone
+	}
+}
+
+// Borrowed from rwmutex_test.go
+func TestRWMutex(t *testing.T) {
+	defer runtime.GOMAXPROCS(runtime.GOMAXPROCS(-1))
+	n := 1000
+	if testing.Short() {
+		n = 5
+	}
+	HammerRWMutex(1, 1, n)
+	HammerRWMutex(1, 3, n)
+	HammerRWMutex(1, 10, n)
+	HammerRWMutex(4, 1, n)
+	HammerRWMutex(4, 3, n)
+	HammerRWMutex(4, 10, n)
+	HammerRWMutex(10, 1, n)
+	HammerRWMutex(10, 3, n)
+	HammerRWMutex(10, 10, n)
+	HammerRWMutex(10, 5, n)
+}
+
+// Borrowed from rwmutex_test.go
+func TestDRLocker(t *testing.T) {
+	wl := NewDRWMutex("test")
+	var rl sync.Locker
+	wlocked := make(chan bool, 1)
+	rlocked := make(chan bool, 1)
+	rl = wl.DRLocker()
+	n := 10
+	go func() {
+		for i := 0; i < n; i++ {
+			rl.Lock()
+			rl.Lock()
+			rlocked <- true
+			wl.Lock()
+			wlocked <- true
+		}
+	}()
+	for i := 0; i < n; i++ {
+		<-rlocked
+		rl.Unlock()
+		select {
+		case <-wlocked:
+			t.Fatal("RLocker() didn't read-lock it")
+		default:
+		}
+		rl.Unlock()
+		<-wlocked
+		select {
+		case <-rlocked:
+			t.Fatal("RLocker() didn't respect the write lock")
+		default:
+		}
+		wl.Unlock()
+	}
+}
+
+// Borrowed from rwmutex_test.go
+func TestUnlockPanic(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatalf("unlock of unlocked RWMutex did not panic")
+		}
+	}()
+	mu := NewDRWMutex("test")
+	mu.Unlock()
+}
+
+// Borrowed from rwmutex_test.go
+func TestUnlockPanic2(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatalf("unlock of unlocked RWMutex did not panic")
+		}
+	}()
+	mu := NewDRWMutex("test-unlock-panic-2")
+	mu.RLock()
+	mu.Unlock()
+}
+
+// Borrowed from rwmutex_test.go
+func TestRUnlockPanic(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatalf("read unlock of unlocked RWMutex did not panic")
+		}
+	}()
+	mu  := NewDRWMutex("test")
+	mu.RUnlock()
+}
+
+// Borrowed from rwmutex_test.go
+func TestRUnlockPanic2(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatalf("read unlock of unlocked RWMutex did not panic")
+		}
+	}()
+	mu := NewDRWMutex("test-runlock-panic-2")
+	mu.Lock()
+	mu.RUnlock()
+}
+
+// Borrowed from rwmutex_test.go
+func benchmarkRWMutex(b *testing.B, localWork, writeRatio int) {
+	rwm := NewDRWMutex("test")
+	b.RunParallel(func(pb *testing.PB) {
+		foo := 0
+		for pb.Next() {
+			foo++
+			if foo%writeRatio == 0 {
+				rwm.Lock()
+				rwm.Unlock()
+			} else {
+				rwm.RLock()
+				for i := 0; i != localWork; i += 1 {
+					foo *= 2
+					foo /= 2
+				}
+				rwm.RUnlock()
+			}
+		}
+		_ = foo
+	})
+}
+
+// Borrowed from rwmutex_test.go
+func BenchmarkRWMutexWrite100(b *testing.B) {
+	benchmarkRWMutex(b, 0, 100)
+}
+
+// Borrowed from rwmutex_test.go
+func BenchmarkRWMutexWrite10(b *testing.B) {
+	benchmarkRWMutex(b, 0, 10)
+}
+
+// Borrowed from rwmutex_test.go
+func BenchmarkRWMutexWorkWrite100(b *testing.B) {
+	benchmarkRWMutex(b, 100, 100)
+}
+
+// Borrowed from rwmutex_test.go
+func BenchmarkRWMutexWorkWrite10(b *testing.B) {
+	benchmarkRWMutex(b, 100, 10)
 }

--- a/rpc-client-impl_test.go
+++ b/rpc-client-impl_test.go
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-package dsync
+package dsync_test
 
 import (
 	"net/rpc"
 	"sync"
 	"time"
+	. "github.com/minio/dsync"
 )
 
 // RPCClient is a wrapper type for rpc.Client which provides reconnect on first failure.


### PR DESCRIPTION
drwmutex.go / drwmutex_test.go:
- DRWMutex made compatible with sync.rwmutex (via writeLocks & readersLocks arrays) so it now allows multiple RLocks() to be done on the same object
- Refactor out common code for Lock/RLock and Unlock/RUnlock
- Added full test harness from sync.rwmutex
- Added benchmarks from sync.rwmutex
- Unlock()/RUnlock() on unlocked object will panic (conform sync.rwmutex)

dsync_test.go:
- Use simple int64 instead of []bool for DRWMutex book keeping (map[string]int64 instead of map[string][]bool)

other changes:
- Updated README.md (still WIP)