### PR TITLE
 Proper increment of the variable within break.

### DIFF
--- a/drwmutex.go
+++ b/drwmutex.go
@@ -230,6 +230,7 @@ func lock(clnts []RPC, locks *[]string, lockName string, isReadLock bool) bool {
 			}
 
 			if done {
+				i++
 				break
 			}
 		}


### PR DESCRIPTION

- Proper increment of the variable `i` within the break statement so
  that the indefinite blocking of the read on channel `ch` is avoided.
 
- This fixes the go routine leakage witnessed during load.

- Fixes https://github.com/minio/minio/issues/3274 . 