### PR TITLE
Make dsync as generic distributed sync.mutex

### DIFF
--- a/chaos/chaos.go
+++ b/chaos/chaos.go
@@ -617,7 +617,7 @@ func testWriterStarvation(wg *sync.WaitGroup, noWriterStarvation bool) {
 	}
 }
 
-func getSelfNode(rpcClnts []dsync.RPCClient, port int) int {
+func getSelfNode(rpcClnts []dsync.NetLocker, port int) int {
 
 	index := -1
 	for i, c := range rpcClnts {
@@ -644,7 +644,7 @@ func main() {
 		if *writeLockFlag != "" || *readLockFlag != "" {
 			go func() {
 				// Initialize net/rpc clients for dsync.
-				var clnts []dsync.RPCClient
+				var clnts []dsync.NetLocker
 				for i := 0; i < n; i++ {
 					clnts = append(clnts, newClient(fmt.Sprintf("127.0.0.1:%d", portStart+i), rpcPathPrefix+"-"+strconv.Itoa(portStart+i)))
 				}
@@ -691,7 +691,7 @@ func main() {
 	servers = append(servers, launchTestServers(1, n-1)...)
 
 	// Initialize net/rpc clients for dsync.
-	var clnts []dsync.RPCClient
+	var clnts []dsync.NetLocker
 	for i := 0; i < n; i++ {
 		clnts = append(clnts, newClient(fmt.Sprintf("127.0.0.1:%d", portStart+i), rpcPathPrefix+"-"+strconv.Itoa(portStart+i)))
 	}

--- a/chaos/net-rpc-client.go
+++ b/chaos/net-rpc-client.go
@@ -20,7 +20,8 @@ import (
 	"errors"
 	"net/rpc"
 	"sync"
-	"time"
+
+	"github.com/minio/dsync"
 )
 
 // ReconnectRPCClient is a wrapper type for rpc.Client which provides reconnect on first failure.
@@ -75,10 +76,7 @@ func (rpcClient *ReconnectRPCClient) dialRPCClient() (*rpc.Client, error) {
 }
 
 // Call makes a RPC call to the remote endpoint using the default codec, namely encoding/gob.
-func (rpcClient *ReconnectRPCClient) Call(serviceMethod string, args interface {
-	SetTimestamp(time.Time)
-	SetToken(string)
-}, reply interface{}) error {
+func (rpcClient *ReconnectRPCClient) Call(serviceMethod string, args interface{}, reply interface{}) error {
 	// Make a copy below so that we can safely (continue to) work with the rpc.Client.
 	// Even in the case the two threads would simultaneously find that the connection is not initialised,
 	// they would both attempt to dial and only one of them would succeed in doing so.
@@ -112,6 +110,31 @@ func (rpcClient *ReconnectRPCClient) Call(serviceMethod string, args interface {
 	return err
 }
 
+func (rpcClient *ReconnectRPCClient) RLock(args dsync.LockArgs) (status bool, err error) {
+	err = rpcClient.Call("Dsync.RLock", &args, &status)
+	return status, err
+}
+
+func (rpcClient *ReconnectRPCClient) Lock(args dsync.LockArgs) (status bool, err error) {
+	err = rpcClient.Call("Dsync.Lock", &args, &status)
+	return status, err
+}
+
+func (rpcClient *ReconnectRPCClient) RUnlock(args dsync.LockArgs) (status bool, err error) {
+	err = rpcClient.Call("Dsync.RUnlock", &args, &status)
+	return status, err
+}
+
+func (rpcClient *ReconnectRPCClient) Unlock(args dsync.LockArgs) (status bool, err error) {
+	err = rpcClient.Call("Dsync.Unlock", &args, &status)
+	return status, err
+}
+
+func (rpcClient *ReconnectRPCClient) ForceUnlock(args dsync.LockArgs) (status bool, err error) {
+	err = rpcClient.Call("Dsync.ForceUnlock", &args, &status)
+	return status, err
+}
+
 // Close closes the underlying socket file descriptor.
 func (rpcClient *ReconnectRPCClient) Close() error {
 	// See comment above for making a copy on local stack
@@ -132,6 +155,6 @@ func (rpcClient *ReconnectRPCClient) ServerAddr() string {
 	return rpcClient.node
 }
 
-func (rpcClient *ReconnectRPCClient) Resource() string {
+func (rpcClient *ReconnectRPCClient) ServiceEndpoint() string {
 	return rpcClient.rpcPath
 }

--- a/drwmutex.go
+++ b/drwmutex.go
@@ -19,7 +19,7 @@ package dsync
 import (
 	cryptorand "crypto/rand"
 	"fmt"
-	"log"
+	golog "log"
 	"math"
 	"math/rand"
 	"net"
@@ -34,6 +34,12 @@ var dsyncLog bool
 func init() {
 	// Check for DSYNC_LOG env variable, if set logging will be enabled for failed RPC operations.
 	dsyncLog = os.Getenv("DSYNC_LOG") == "1"
+}
+
+func log(msg ...interface{}) {
+	if dsyncLog {
+		golog.Println(msg...)
+	}
 }
 
 // DRWMutexAcquireTimeout - tolerance limit to wait for lock acquisition before.
@@ -58,23 +64,6 @@ func (g *Granted) isLocked() bool {
 
 func isLocked(uid string) bool {
 	return len(uid) > 0
-}
-
-type LockArgs struct {
-	Token      string
-	Timestamp  time.Time
-	Name       string
-	ServerAddr string
-	Resource   string
-	UID        string
-}
-
-func (l *LockArgs) SetToken(token string) {
-	l.Token = token
-}
-
-func (l *LockArgs) SetTimestamp(tstamp time.Time) {
-	l.Timestamp = tstamp
 }
 
 func NewDRWMutex(name string) *DRWMutex {
@@ -152,7 +141,7 @@ func (dm *DRWMutex) lockBlocking(isReadLock bool) {
 
 // lock tries to acquire the distributed lock, returning true or false
 //
-func lock(clnts []RPCClient, locks *[]string, lockName string, isReadLock bool) bool {
+func lock(clnts []NetLocker, locks *[]string, lockName string, isReadLock bool) bool {
 
 	// Create buffered channel of size equal to total number of nodes.
 	ch := make(chan Granted, dnodeCount)
@@ -160,25 +149,29 @@ func lock(clnts []RPCClient, locks *[]string, lockName string, isReadLock bool) 
 	for index, c := range clnts {
 
 		// broadcast lock request to all nodes
-		go func(index int, isReadLock bool, c RPCClient) {
+		go func(index int, isReadLock bool, c NetLocker) {
 			// All client methods issuing RPCs are thread-safe and goroutine-safe,
 			// i.e. it is safe to call them from multiple concurrently running go routines.
-			var locked bool
 			bytesUid := [16]byte{}
 			cryptorand.Read(bytesUid[:])
 			uid := fmt.Sprintf("%X", bytesUid[:])
-			args := LockArgs{Name: lockName, ServerAddr: clnts[ownNode].ServerAddr(), Resource: clnts[ownNode].Resource(), UID: uid}
+
+			args := LockArgs{
+				UID:             uid,
+				Resource:        lockName,
+				ServerAddr:      clnts[ownNode].ServerAddr(),
+				ServiceEndpoint: clnts[ownNode].ServiceEndpoint(),
+			}
+
+			var locked bool
+			var err error
 			if isReadLock {
-				if err := c.Call("Dsync.RLock", &args, &locked); err != nil {
-					if dsyncLog {
-						log.Println("Unable to call Dsync.RLock", err)
-					}
+				if locked, err = c.RLock(args); err != nil {
+					log("Unable to call RLock", err)
 				}
 			} else {
-				if err := c.Call("Dsync.Lock", &args, &locked); err != nil {
-					if dsyncLog {
-						log.Println("Unable to call Dsync.Lock", err)
-					}
+				if locked, err = c.Lock(args); err != nil {
+					log("Unable to call Lock", err)
 				}
 			}
 
@@ -284,7 +277,7 @@ func quorumMet(locks *[]string, isReadLock bool) bool {
 }
 
 // releaseAll releases all locks that are marked as locked
-func releaseAll(clnts []RPCClient, locks *[]string, lockName string, isReadLock bool) {
+func releaseAll(clnts []NetLocker, locks *[]string, lockName string, isReadLock bool) {
 	for lock := 0; lock < dnodeCount; lock++ {
 		if isLocked((*locks)[lock]) {
 			sendRelease(clnts[lock], lockName, (*locks)[lock], isReadLock)
@@ -385,7 +378,7 @@ func (dm *DRWMutex) ForceUnlock() {
 }
 
 // sendRelease sends a release message to a node that previously granted a lock
-func sendRelease(c RPCClient, name, uid string, isReadLock bool) {
+func sendRelease(c NetLocker, name, uid string, isReadLock bool) {
 
 	backOffArray := []time.Duration{
 		30 * time.Second, // 30secs.
@@ -396,53 +389,45 @@ func sendRelease(c RPCClient, name, uid string, isReadLock bool) {
 		1 * time.Hour,    // 1hr.
 	}
 
-	go func(c RPCClient, name string) {
+	go func(c NetLocker, name string) {
 
 		for _, backOff := range backOffArray {
 
 			// All client methods issuing RPCs are thread-safe and goroutine-safe,
 			// i.e. it is safe to call them from multiple concurrently running goroutines.
-			var unlocked bool
-			args := LockArgs{Name: name, UID: uid} // Just send name & uid (and leave out node and rpcPath; unimportant for unlocks)
+			args := LockArgs{
+				UID:             uid,
+				Resource:        name,
+				ServerAddr:      clnts[ownNode].ServerAddr(),
+				ServiceEndpoint: clnts[ownNode].ServiceEndpoint(),
+			}
+
+			var err error
 			if len(uid) == 0 {
-				if err := c.Call("Dsync.ForceUnlock", &args, &unlocked); err == nil {
-					// ForceUnlock delivered, exit out
-					return
-				} else if err != nil {
-					if dsyncLog {
-						log.Println("Unable to call Dsync.ForceUnlock", err)
-					}
-					if nErr, ok := err.(net.Error); ok && nErr.Timeout() {
-						// ForceUnlock possibly failed with server timestamp mismatch, server may have restarted.
-						return
-					}
+				if _, err = c.ForceUnlock(args); err != nil {
+					log("Unable to call ForceUnlock", err)
 				}
 			} else if isReadLock {
-				if err := c.Call("Dsync.RUnlock", &args, &unlocked); err == nil {
-					// RUnlock delivered, exit out
-					return
-				} else if err != nil {
-					if dsyncLog {
-						log.Println("Unable to call Dsync.RUnlock", err)
-					}
-					if nErr, ok := err.(net.Error); ok && nErr.Timeout() {
-						// RUnlock possibly failed with server timestamp mismatch, server may have restarted.
-						return
-					}
+				if _, err = c.RUnlock(args); err != nil {
+					log("Unable to call RUnlock", err)
 				}
 			} else {
-				if err := c.Call("Dsync.Unlock", &args, &unlocked); err == nil {
-					// Unlock delivered, exit out
-					return
-				} else if err != nil {
-					if dsyncLog {
-						log.Println("Unable to call Dsync.Unlock", err)
-					}
-					if nErr, ok := err.(net.Error); ok && nErr.Timeout() {
-						// Unlock possibly failed with server timestamp mismatch, server may have restarted.
-						return
-					}
+				if _, err = c.Unlock(args); err != nil {
+					log("Unable to call Unlock", err)
 				}
+			}
+
+			if err != nil {
+				// Ignore if err is net.Error and it is occurred due to timeout.
+				// The cause could have been server timestamp mismatch or server may have restarted.
+				// FIXME: This is minio specific behaviour and we would need a way to make it generically.
+				if nErr, ok := err.(net.Error); ok && nErr.Timeout() {
+					err = nil
+				}
+			}
+
+			if err == nil {
+				return
 			}
 
 			// Wait..

--- a/dsync-server_test.go
+++ b/dsync-server_test.go
@@ -17,16 +17,11 @@
 package dsync_test
 
 import (
-	"errors"
 	"fmt"
 	"sync"
-	"time"
 
 	. "github.com/minio/dsync"
 )
-
-// used when cached timestamp do not match with what client remembers.
-var errInvalidTimestamp = errors.New("Timestamps don't match, server may have restarted.")
 
 const WriteLock = -1
 
@@ -34,25 +29,14 @@ type lockServer struct {
 	mutex sync.Mutex
 	// Map of locks, with negative value indicating (exclusive) write lock
 	// and positive values indicating number of read locks
-	lockMap   map[string]int64
-	timestamp time.Time // Timestamp set at the time of initialization. Resets naturally on minio server restart.
-}
-
-func (l *lockServer) verifyArgs(args *LockArgs) error {
-	if !l.timestamp.Equal(args.Timestamp) {
-		return errInvalidTimestamp
-	}
-	return nil
+	lockMap map[string]int64
 }
 
 func (l *lockServer) Lock(args *LockArgs, reply *bool) error {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
-	if err := l.verifyArgs(args); err != nil {
-		return err
-	}
-	if _, *reply = l.lockMap[args.Name]; !*reply {
-		l.lockMap[args.Name] = WriteLock // No locks held on the given name, so claim write lock
+	if _, *reply = l.lockMap[args.Resource]; !*reply {
+		l.lockMap[args.Resource] = WriteLock // No locks held on the given name, so claim write lock
 	}
 	*reply = !*reply // Negate *reply to return true when lock is granted or false otherwise
 	return nil
@@ -61,17 +45,14 @@ func (l *lockServer) Lock(args *LockArgs, reply *bool) error {
 func (l *lockServer) Unlock(args *LockArgs, reply *bool) error {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
-	if err := l.verifyArgs(args); err != nil {
-		return err
-	}
 	var locksHeld int64
-	if locksHeld, *reply = l.lockMap[args.Name]; !*reply { // No lock is held on the given name
-		return fmt.Errorf("Unlock attempted on an unlocked entity: %s", args.Name)
+	if locksHeld, *reply = l.lockMap[args.Resource]; !*reply { // No lock is held on the given name
+		return fmt.Errorf("Unlock attempted on an unlocked entity: %s", args.Resource)
 	}
 	if *reply = locksHeld == WriteLock; !*reply { // Unless it is a write lock
-		return fmt.Errorf("Unlock attempted on a read locked entity: %s (%d read locks active)", args.Name, locksHeld)
+		return fmt.Errorf("Unlock attempted on a read locked entity: %s (%d read locks active)", args.Resource, locksHeld)
 	}
-	delete(l.lockMap, args.Name) // Remove the write lock
+	delete(l.lockMap, args.Resource) // Remove the write lock
 	return nil
 }
 
@@ -80,16 +61,13 @@ const ReadLock = 1
 func (l *lockServer) RLock(args *LockArgs, reply *bool) error {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
-	if err := l.verifyArgs(args); err != nil {
-		return err
-	}
 	var locksHeld int64
-	if locksHeld, *reply = l.lockMap[args.Name]; !*reply {
-		l.lockMap[args.Name] = ReadLock // No locks held on the given name, so claim (first) read lock
+	if locksHeld, *reply = l.lockMap[args.Resource]; !*reply {
+		l.lockMap[args.Resource] = ReadLock // No locks held on the given name, so claim (first) read lock
 		*reply = true
 	} else {
 		if *reply = locksHeld != WriteLock; *reply { // Unless there is a write lock
-			l.lockMap[args.Name] = locksHeld + ReadLock // Grant another read lock
+			l.lockMap[args.Resource] = locksHeld + ReadLock // Grant another read lock
 		}
 	}
 	return nil
@@ -98,20 +76,17 @@ func (l *lockServer) RLock(args *LockArgs, reply *bool) error {
 func (l *lockServer) RUnlock(args *LockArgs, reply *bool) error {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
-	if err := l.verifyArgs(args); err != nil {
-		return err
-	}
 	var locksHeld int64
-	if locksHeld, *reply = l.lockMap[args.Name]; !*reply { // No lock is held on the given name
-		return fmt.Errorf("RUnlock attempted on an unlocked entity: %s", args.Name)
+	if locksHeld, *reply = l.lockMap[args.Resource]; !*reply { // No lock is held on the given name
+		return fmt.Errorf("RUnlock attempted on an unlocked entity: %s", args.Resource)
 	}
 	if *reply = locksHeld != WriteLock; !*reply { // A write-lock is held, cannot release a read lock
-		return fmt.Errorf("RUnlock attempted on a write locked entity: %s", args.Name)
+		return fmt.Errorf("RUnlock attempted on a write locked entity: %s", args.Resource)
 	}
 	if locksHeld > ReadLock {
-		l.lockMap[args.Name] = locksHeld - ReadLock // Remove one of the read locks held
+		l.lockMap[args.Resource] = locksHeld - ReadLock // Remove one of the read locks held
 	} else {
-		delete(l.lockMap, args.Name) // Remove the (last) read lock
+		delete(l.lockMap, args.Resource) // Remove the (last) read lock
 	}
 	return nil
 }
@@ -119,14 +94,11 @@ func (l *lockServer) RUnlock(args *LockArgs, reply *bool) error {
 func (l *lockServer) ForceUnlock(args *LockArgs, reply *bool) error {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
-	if err := l.verifyArgs(args); err != nil {
-		return err
-	}
 	if len(args.UID) != 0 {
 		return fmt.Errorf("ForceUnlock called with non-empty UID: %s", args.UID)
 	}
-	if _, ok := l.lockMap[args.Name]; ok { // Only clear lock when set
-		delete(l.lockMap, args.Name) // Remove the lock (irrespective of write or read lock)
+	if _, ok := l.lockMap[args.Resource]; ok { // Only clear lock when set
+		delete(l.lockMap, args.Resource) // Remove the lock (irrespective of write or read lock)
 	}
 	*reply = true
 	return nil

--- a/dsync.go
+++ b/dsync.go
@@ -22,7 +22,7 @@ import "errors"
 var dnodeCount int
 
 // List of rpc client objects, one per lock server.
-var clnts []RPCClient
+var clnts []NetLocker
 
 // Index into rpc client array for server running on localhost
 var ownNode int
@@ -36,7 +36,7 @@ var dquorumReads int
 // Init - initializes package-level global state variables such as clnts.
 // N B - This function should be called only once inside any program
 // that uses dsync.
-func Init(rpcClnts []RPCClient, rpcOwnNode int) (err error) {
+func Init(rpcClnts []NetLocker, rpcOwnNode int) (err error) {
 
 	// Validate if number of nodes is within allowable range.
 	if dnodeCount != 0 {
@@ -57,8 +57,8 @@ func Init(rpcClnts []RPCClient, rpcOwnNode int) (err error) {
 	dnodeCount = len(rpcClnts)
 	dquorum = dnodeCount/2 + 1
 	dquorumReads = dnodeCount / 2
-	// Initialize node name and rpc path for each RPCClient object.
-	clnts = make([]RPCClient, dnodeCount)
+	// Initialize node name and rpc path for each NetLocker object.
+	clnts = make([]NetLocker, dnodeCount)
 	copy(clnts, rpcClnts)
 
 	ownNode = rpcOwnNode

--- a/dsync_test.go
+++ b/dsync_test.go
@@ -74,7 +74,7 @@ func TestMain(m *testing.M) {
 	}
 
 	// Initialize net/rpc clients for dsync.
-	var clnts []RPCClient
+	var clnts []NetLocker
 	for i := 0; i < len(nodes); i++ {
 		clnts = append(clnts, newClient(nodes[i], rpcPaths[i]))
 	}
@@ -87,12 +87,12 @@ func TestMain(m *testing.M) {
 		log.Fatalf("Should have failed")
 	}
 
-	nclnts := make([]RPCClient, 17)
+	nclnts := make([]NetLocker, 17)
 	if err := Init(nclnts, 0); err == nil {
 		log.Fatalf("Should have failed")
 	}
 
-	nclnts = make([]RPCClient, 15)
+	nclnts = make([]NetLocker, 15)
 	if err := Init(nclnts, 0); err == nil {
 		log.Fatalf("Should have failed")
 	}

--- a/examples/auth-locker/auth-lock-client.go
+++ b/examples/auth-locker/auth-lock-client.go
@@ -1,0 +1,196 @@
+/*
+ * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"bufio"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"net/rpc"
+	"sync"
+	"time"
+
+	"github.com/minio/dsync"
+)
+
+// defaultDialTimeout is used for non-secure connection.
+const defaultDialTimeout = 3 * time.Second
+
+// ReconnectRPCClient is a wrapper type for rpc.Client which provides reconnect on first failure.
+type ReconnectRPCClient struct {
+	mutex           sync.Mutex
+	netRPCClient    *rpc.Client
+	serverAddr      string
+	serviceEndpoint string
+	sessionID       string
+}
+
+// newReconnectRPCClient constructs a new ReconnectRPCClient object with given serverAddr
+// and serviceEndpoint.  It does lazy connect to serverAddr on Call().
+func newReconnectRPCClient(serverAddr, serviceEndpoint string) *ReconnectRPCClient {
+	return &ReconnectRPCClient{
+		serverAddr:      serverAddr,
+		serviceEndpoint: serviceEndpoint,
+	}
+}
+
+// dial tries to establish a connection to serverAddr in a safe manner.
+// If there is a valid rpc.Cliemt, it returns that else creates a new one.
+func (rpcClient *ReconnectRPCClient) dial() (*rpc.Client, error) {
+	rpcClient.mutex.Lock()
+	defer rpcClient.mutex.Unlock()
+
+	// Nothing to do as we already have valid connection.
+	if rpcClient.netRPCClient != nil {
+		return rpcClient.netRPCClient, nil
+	}
+
+	// Dial with 3 seconds timeout.
+	conn, err := net.DialTimeout("tcp", rpcClient.serverAddr, defaultDialTimeout)
+	if err != nil {
+		// Print RPC connection errors that are worthy to display in log
+		switch err.(type) {
+		case x509.HostnameError:
+			log.Println("Unable to establish secure connection to", rpcClient.serverAddr)
+			log.Println("error:", err)
+		}
+		return nil, &net.OpError{
+			Op:   "dial-http",
+			Net:  rpcClient.serverAddr + " " + rpcClient.serviceEndpoint,
+			Addr: nil,
+			Err:  err,
+		}
+	}
+
+	io.WriteString(conn, "CONNECT "+rpcClient.serviceEndpoint+" HTTP/1.0\n\n")
+
+	// Require successful HTTP response before switching to RPC protocol.
+	resp, err := http.ReadResponse(bufio.NewReader(conn), &http.Request{Method: "CONNECT"})
+	if err == nil && resp.Status == "200 Connected to Go RPC" {
+		netRPCClient := rpc.NewClient(conn)
+		if netRPCClient == nil {
+			return nil, &net.OpError{
+				Op:   "dial-http",
+				Net:  rpcClient.serverAddr + " " + rpcClient.serviceEndpoint,
+				Addr: nil,
+				Err:  fmt.Errorf("Unable to initialize new rpc.Client"),
+			}
+		}
+
+		rpcClient.netRPCClient = netRPCClient
+
+		return netRPCClient, nil
+	}
+
+	if err == nil {
+		err = errors.New("unexpected HTTP response: " + resp.Status)
+	}
+
+	conn.Close()
+	return nil, &net.OpError{
+		Op:   "dial-http",
+		Net:  rpcClient.serverAddr + " " + rpcClient.serviceEndpoint,
+		Addr: nil,
+		Err:  err,
+	}
+}
+
+// Call makes a RPC call to the remote endpoint using the default
+// codec, namely encoding/gob.  It logs in automatically when session ID
+// is empty.
+func (rpcClient *ReconnectRPCClient) Call(serviceMethod string, args interface{}, reply interface{}) error {
+	// Get a new or existing rpc.Client.
+	netRPCClient, err := rpcClient.dial()
+	if err != nil {
+		return err
+	}
+
+	rpcClient.mutex.Lock()
+	if rpcClient.sessionID == "" {
+		loginArgs := NewLoginArgs("admin", "adm1npasswo7d")
+		if err = rpcClient.Call("LockServer.Login", &loginArgs, &rpcClient.sessionID); err != nil {
+			rpcClient.mutex.Unlock()
+			return err
+		}
+	}
+	rpcClient.mutex.Unlock()
+
+	return netRPCClient.Call(serviceMethod, args, reply)
+}
+
+func (rpcClient *ReconnectRPCClient) RLock(args dsync.LockArgs) (status bool, err error) {
+	lockArgs := NewLockArgs(args, rpcClient.sessionID)
+	err = rpcClient.Call("LockServer.RLock", &lockArgs, &status)
+	return status, err
+}
+
+func (rpcClient *ReconnectRPCClient) Lock(args dsync.LockArgs) (status bool, err error) {
+	lockArgs := NewLockArgs(args, rpcClient.sessionID)
+	err = rpcClient.Call("LockServer.Lock", &lockArgs, &status)
+	return status, err
+}
+
+func (rpcClient *ReconnectRPCClient) RUnlock(args dsync.LockArgs) (status bool, err error) {
+	lockArgs := NewLockArgs(args, rpcClient.sessionID)
+	err = rpcClient.Call("LockServer.RUnlock", &lockArgs, &status)
+	return status, err
+}
+
+func (rpcClient *ReconnectRPCClient) Unlock(args dsync.LockArgs) (status bool, err error) {
+	lockArgs := NewLockArgs(args, rpcClient.sessionID)
+	err = rpcClient.Call("LockServer.Unlock", &lockArgs, &status)
+	return status, err
+}
+
+func (rpcClient *ReconnectRPCClient) ForceUnlock(args dsync.LockArgs) (status bool, err error) {
+	lockArgs := NewLockArgs(args, rpcClient.sessionID)
+	err = rpcClient.Call("LockServer.ForceUnlock", &lockArgs, &status)
+	return status, err
+}
+
+// Close closes the underlying socket file descriptor.
+func (rpcClient *ReconnectRPCClient) Close() (err error) {
+	rpcClient.mutex.Lock()
+	netRPCClient := rpcClient.netRPCClient
+	rpcClient.mutex.Unlock()
+
+	if netRPCClient != nil {
+		var status bool
+		rpcClient.Call("LockServer.Logout", &rpcClient.sessionID, &status)
+
+		rpcClient.mutex.Lock()
+		rpcClient.netRPCClient = nil
+		rpcClient.mutex.Unlock()
+
+		netRPCClient.Close()
+	}
+
+	return nil
+}
+
+func (rpcClient *ReconnectRPCClient) ServerAddr() string {
+	return rpcClient.serverAddr
+}
+
+func (rpcClient *ReconnectRPCClient) ServiceEndpoint() string {
+	return rpcClient.serviceEndpoint
+}

--- a/examples/auth-locker/auth-lock-server.go
+++ b/examples/auth-locker/auth-lock-server.go
@@ -1,0 +1,243 @@
+/*
+ * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"errors"
+	"math/rand"
+	"sync"
+)
+
+const (
+	defaultUsername = "admin"
+	defaultPassword = "adm1npasswo7d"
+	letterBytes     = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+)
+
+var validResources = []string{"Music", "Videos", "Downloads"}
+
+func isValidResource(resource string) bool {
+	for _, validResource := range validResources {
+		if validResource == resource {
+			return true
+		}
+	}
+
+	return false
+}
+
+func genSessionID() string {
+	b := make([]byte, 16)
+
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+
+	return "AUTHLOCKER-" + string(b)
+}
+
+type LockServer struct {
+	resourceLockMapMutex sync.Mutex
+	resourceLockMap      map[string][]int
+
+	sessionListMutex sync.Mutex
+	sessionList      map[string]struct{}
+}
+
+func (ls *LockServer) Login(args *LoginArgs, sessionID *string) error {
+	if !(args.username == defaultUsername && args.password == defaultPassword) {
+		return errors.New("Unknown username or password")
+	}
+
+	newSessionID := genSessionID()
+
+	ls.sessionListMutex.Lock()
+	defer ls.sessionListMutex.Unlock()
+
+	if _, ok := ls.sessionList[newSessionID]; ok {
+		return errors.New("Internal error.  Try again later")
+	}
+
+	ls.sessionList[newSessionID] = struct{}{}
+
+	*sessionID = newSessionID
+
+	return nil
+}
+
+func (ls *LockServer) Logout(sessionID *string, reply *bool) error {
+	ls.sessionListMutex.Lock()
+	defer ls.sessionListMutex.Unlock()
+
+	if _, ok := ls.sessionList[*sessionID]; !ok {
+		return errors.New("No such session ID")
+	}
+
+	delete(ls.sessionList, *sessionID)
+
+	*reply = true
+
+	return nil
+}
+
+func (ls *LockServer) isLoggedIn(sessionID string) bool {
+	ls.sessionListMutex.Lock()
+	defer ls.sessionListMutex.Unlock()
+
+	_, ok := ls.sessionList[sessionID]
+	return ok
+}
+
+func (ls *LockServer) RLock(args *LockArgs, reply *bool) error {
+	if !ls.isLoggedIn(args.SessionID) {
+		return errors.New("Not logged in")
+	}
+
+	if !isValidResource(args.LockArgs.Resource) {
+		return errors.New("Invalid resource")
+	}
+
+	ls.resourceLockMapMutex.Lock()
+	defer ls.resourceLockMapMutex.Unlock()
+
+	counters, ok := ls.resourceLockMap[args.LockArgs.Resource]
+	if !ok {
+		counters = make([]int, 2)
+	}
+
+	counters[0]++
+	ls.resourceLockMap[args.LockArgs.Resource] = counters
+
+	*reply = true
+
+	return nil
+}
+
+func (ls *LockServer) Lock(args *LockArgs, reply *bool) error {
+	if !ls.isLoggedIn(args.SessionID) {
+		return errors.New("Not logged in")
+	}
+
+	if !isValidResource(args.LockArgs.Resource) {
+		return errors.New("Invalid resource")
+	}
+
+	ls.resourceLockMapMutex.Lock()
+	defer ls.resourceLockMapMutex.Unlock()
+
+	counters, ok := ls.resourceLockMap[args.LockArgs.Resource]
+	if !ok {
+		counters = make([]int, 2)
+	}
+
+	counters[1]++
+	ls.resourceLockMap[args.LockArgs.Resource] = counters
+
+	*reply = true
+
+	return nil
+}
+
+func (ls *LockServer) RUnlock(args *LockArgs, reply *bool) error {
+	if !ls.isLoggedIn(args.SessionID) {
+		return errors.New("Not logged in")
+	}
+
+	if !isValidResource(args.LockArgs.Resource) {
+		return errors.New("Invalid resource")
+	}
+
+	ls.resourceLockMapMutex.Lock()
+	defer ls.resourceLockMapMutex.Unlock()
+
+	counters, ok := ls.resourceLockMap[args.LockArgs.Resource]
+	if !ok {
+		return errors.New("No lock found")
+	}
+
+	if counters[0] <= 0 {
+		*reply = false
+		return nil
+	}
+
+	counters[0]--
+	if counters[0] == 0 && counters[1] == 0 {
+		delete(ls.resourceLockMap, args.LockArgs.Resource)
+	} else {
+		ls.resourceLockMap[args.LockArgs.Resource] = counters
+	}
+
+	*reply = true
+
+	return nil
+}
+
+func (ls *LockServer) Unlock(args *LockArgs, reply *bool) error {
+	if !ls.isLoggedIn(args.SessionID) {
+		return errors.New("Not logged in")
+	}
+
+	if !isValidResource(args.LockArgs.Resource) {
+		return errors.New("Invalid resource")
+	}
+
+	ls.resourceLockMapMutex.Lock()
+	defer ls.resourceLockMapMutex.Unlock()
+
+	counters, ok := ls.resourceLockMap[args.LockArgs.Resource]
+	if !ok {
+		return errors.New("No lock found")
+	}
+
+	if counters[1] <= 0 {
+		*reply = false
+		return nil
+	}
+
+	counters[1]--
+	if counters[0] == 0 && counters[1] == 0 {
+		delete(ls.resourceLockMap, args.LockArgs.Resource)
+	} else {
+		ls.resourceLockMap[args.LockArgs.Resource] = counters
+	}
+
+	*reply = true
+
+	return nil
+}
+
+func (ls *LockServer) ForceUnlock(args *LockArgs, reply *bool) error {
+	if !ls.isLoggedIn(args.SessionID) {
+		return errors.New("Not logged in")
+	}
+
+	if !isValidResource(args.LockArgs.Resource) {
+		return errors.New("Invalid resource")
+	}
+
+	ls.resourceLockMapMutex.Lock()
+	defer ls.resourceLockMapMutex.Unlock()
+
+	_, ok := ls.resourceLockMap[args.LockArgs.Resource]
+	if !ok {
+		return errors.New("No lock found")
+	}
+
+	*reply = false
+
+	return errors.New("ForceUnlock is not supported")
+}

--- a/examples/auth-locker/common.go
+++ b/examples/auth-locker/common.go
@@ -1,0 +1,39 @@
+/*
+ * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import "github.com/minio/dsync"
+
+const serviceEndpointPrefix = "/lockserver-"
+
+type LockArgs struct {
+	dsync.LockArgs
+	SessionID string
+}
+
+func NewLockArgs(args dsync.LockArgs, sessionID string) LockArgs {
+	return LockArgs{args, sessionID}
+}
+
+type LoginArgs struct {
+	username string
+	password string
+}
+
+func NewLoginArgs(username, password string) LoginArgs {
+	return LoginArgs{username, password}
+}

--- a/examples/auth-locker/main.go
+++ b/examples/auth-locker/main.go
@@ -1,0 +1,55 @@
+/*
+ * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"log"
+	"strconv"
+
+	"github.com/minio/dsync"
+)
+
+const basePort = 50001
+
+func main() {
+	// Start four lock servers.
+	for i := 0; i < 4; i++ {
+		go StartLockServer(basePort + i)
+	}
+
+	// Create four lock clients.
+	lockClients := make([]dsync.NetLocker, 4)
+	for i := 0; i < 4; i++ {
+		lockClients[i] = newReconnectRPCClient("localhost", serviceEndpointPrefix+strconv.Itoa(basePort+i))
+	}
+
+	// Initialize dsync and treat 0th index on lockClients as self node.
+	if err := dsync.Init(lockClients, 0); err != nil {
+		log.Fatal("Fail to initialize dsync.", err)
+	}
+
+	// Get new distributed RWMutex on resource "Music"
+	drwMutex := dsync.NewDRWMutex("Music")
+
+	// Lock "music" resource.
+	drwMutex.Lock()
+
+	// As we got writable lock on Music, do some crazy things.
+
+	// Unlock "Music" resource.
+	drwMutex.Unlock()
+}

--- a/examples/auth-locker/server.go
+++ b/examples/auth-locker/server.go
@@ -1,0 +1,52 @@
+/*
+ * Minio Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"log"
+	"net"
+	"net/http"
+	"net/rpc"
+	"strconv"
+	"sync"
+)
+
+func StartLockServer(port int) {
+	lockServer := &LockServer{
+		resourceLockMapMutex: sync.Mutex{},
+		resourceLockMap:      make(map[string][]int),
+		sessionListMutex:     sync.Mutex{},
+		sessionList:          make(map[string]struct{}),
+	}
+
+	portString := strconv.Itoa(port)
+	rpcPath := serviceEndpointPrefix + portString
+
+	rpcServer := rpc.NewServer()
+	rpcServer.RegisterName("LockServer", lockServer)
+	rpcServer.HandleHTTP(rpcPath, rpcPath)
+
+	listener, err := net.Listen("tcp", ":"+portString)
+	if err == nil {
+		log.Println("LockServer listening at port", port, "under", rpcPath)
+		http.Serve(listener, nil)
+		// It never returns
+	}
+
+	log.Println("Unable to start LockServer on port", port, "under", rpcPath)
+	log.Fatal("error:", err)
+}

--- a/performance/performance-server.go
+++ b/performance/performance-server.go
@@ -17,15 +17,11 @@
 package main
 
 import (
-	"errors"
 	"fmt"
-	"github.com/minio/dsync"
 	"sync"
-	"time"
-)
 
-// used when cached timestamp do not match with what client remembers.
-var errInvalidTimestamp = errors.New("Timestamps don't match, server may have restarted.")
+	"github.com/minio/dsync"
+)
 
 const WriteLock = -1
 
@@ -33,25 +29,14 @@ type lockServer struct {
 	mutex sync.Mutex
 	// Map of locks, with negative value indicating (exclusive) write lock
 	// and positive values indicating number of read locks
-	lockMap   map[string]int64
-	timestamp time.Time // Timestamp set at the time of initialization. Resets naturally on minio server restart.
-}
-
-func (l *lockServer) verifyArgs(args *dsync.LockArgs) error {
-	if !l.timestamp.Equal(args.Timestamp) {
-		return errInvalidTimestamp
-	}
-	return nil
+	lockMap map[string]int64
 }
 
 func (l *lockServer) Lock(args *dsync.LockArgs, reply *bool) error {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
-	if err := l.verifyArgs(args); err != nil {
-		return err
-	}
-	if _, *reply = l.lockMap[args.Name]; !*reply {
-		l.lockMap[args.Name] = WriteLock // No locks held on the given name, so claim write lock
+	if _, *reply = l.lockMap[args.Resource]; !*reply {
+		l.lockMap[args.Resource] = WriteLock // No locks held on the given name, so claim write lock
 	}
 	*reply = !*reply // Negate *reply to return true when lock is granted or false otherwise
 	return nil
@@ -60,17 +45,14 @@ func (l *lockServer) Lock(args *dsync.LockArgs, reply *bool) error {
 func (l *lockServer) Unlock(args *dsync.LockArgs, reply *bool) error {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
-	if err := l.verifyArgs(args); err != nil {
-		return err
-	}
 	var locksHeld int64
-	if locksHeld, *reply = l.lockMap[args.Name]; !*reply { // No lock is held on the given name
-		return fmt.Errorf("Unlock attempted on an unlocked entity: %s", args.Name)
+	if locksHeld, *reply = l.lockMap[args.Resource]; !*reply { // No lock is held on the given name
+		return fmt.Errorf("Unlock attempted on an unlocked entity: %s", args.Resource)
 	}
 	if *reply = locksHeld == WriteLock; !*reply { // Unless it is a write lock
-		return fmt.Errorf("Unlock attempted on a read locked entity: %s (%d read locks active)", args.Name, locksHeld)
+		return fmt.Errorf("Unlock attempted on a read locked entity: %s (%d read locks active)", args.Resource, locksHeld)
 	}
-	delete(l.lockMap, args.Name) // Remove the write lock
+	delete(l.lockMap, args.Resource) // Remove the write lock
 	return nil
 }
 
@@ -79,16 +61,13 @@ const ReadLock = 1
 func (l *lockServer) RLock(args *dsync.LockArgs, reply *bool) error {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
-	if err := l.verifyArgs(args); err != nil {
-		return err
-	}
 	var locksHeld int64
-	if locksHeld, *reply = l.lockMap[args.Name]; !*reply {
-		l.lockMap[args.Name] = ReadLock // No locks held on the given name, so claim (first) read lock
+	if locksHeld, *reply = l.lockMap[args.Resource]; !*reply {
+		l.lockMap[args.Resource] = ReadLock // No locks held on the given name, so claim (first) read lock
 		*reply = true
 	} else {
 		if *reply = locksHeld != WriteLock; *reply { // Unless there is a write lock
-			l.lockMap[args.Name] = locksHeld + ReadLock // Grant another read lock
+			l.lockMap[args.Resource] = locksHeld + ReadLock // Grant another read lock
 		}
 	}
 	return nil
@@ -97,20 +76,17 @@ func (l *lockServer) RLock(args *dsync.LockArgs, reply *bool) error {
 func (l *lockServer) RUnlock(args *dsync.LockArgs, reply *bool) error {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
-	if err := l.verifyArgs(args); err != nil {
-		return err
-	}
 	var locksHeld int64
-	if locksHeld, *reply = l.lockMap[args.Name]; !*reply { // No lock is held on the given name
-		return fmt.Errorf("RUnlock attempted on an unlocked entity: %s", args.Name)
+	if locksHeld, *reply = l.lockMap[args.Resource]; !*reply { // No lock is held on the given name
+		return fmt.Errorf("RUnlock attempted on an unlocked entity: %s", args.Resource)
 	}
 	if *reply = locksHeld != WriteLock; !*reply { // A write-lock is held, cannot release a read lock
-		return fmt.Errorf("RUnlock attempted on a write locked entity: %s", args.Name)
+		return fmt.Errorf("RUnlock attempted on a write locked entity: %s", args.Resource)
 	}
 	if locksHeld > ReadLock {
-		l.lockMap[args.Name] = locksHeld - ReadLock // Remove one of the read locks held
+		l.lockMap[args.Resource] = locksHeld - ReadLock // Remove one of the read locks held
 	} else {
-		delete(l.lockMap, args.Name) // Remove the (last) read lock
+		delete(l.lockMap, args.Resource) // Remove the (last) read lock
 	}
 	return nil
 }

--- a/performance/performance.go
+++ b/performance/performance.go
@@ -110,7 +110,7 @@ func main() {
 	}
 
 	// Initialize net/rpc clients for dsync.
-	var clnts []dsync.RPCClient
+	var clnts []dsync.NetLocker
 	for i := 0; i < len(servers); i++ {
 		clnts = append(clnts, newClient(servers[i], resources[i]))
 	}
@@ -173,7 +173,7 @@ func main() {
 	}
 }
 
-func getSelfNode(rpcClnts []dsync.RPCClient, port int) int {
+func getSelfNode(rpcClnts []dsync.NetLocker, port int) int {
 
 	index := -1
 	for i, c := range rpcClnts {

--- a/rpc-client-interface.go
+++ b/rpc-client-interface.go
@@ -16,15 +16,51 @@
 
 package dsync
 
-import "time"
+// LockArgs is minimal required values for any dsync compatible lock operation.
+type LockArgs struct {
+	// Unique ID of lock/unlock request.
+	UID string
 
-// RPCClient - is dsync compatible client interface.
-type RPCClient interface {
-	Call(serviceMethod string, args interface {
-		SetToken(token string)
-		SetTimestamp(tstamp time.Time)
-	}, reply interface{}) error
-	Close() error
+	// Resource contains a entity to be locked/unlocked.
+	Resource string
+
+	// ServerAddr contains the address of the server who requested lock/unlock of the above resource.
+	ServerAddr string
+
+	// ServiceEndpoint contains the network path of above server to do lock/unlock.
+	ServiceEndpoint string
+}
+
+// NetLocker is dsync compatible locker interface.
+type NetLocker interface {
+	// Do read lock for given LockArgs.  It should return
+	// * a boolean to indicate success/failure of the operation
+	// * an error on failure of lock request operation.
+	RLock(args LockArgs) (bool, error)
+
+	// Do write lock for given LockArgs. It should return
+	// * a boolean to indicate success/failure of the operation
+	// * an error on failure of lock request operation.
+	Lock(args LockArgs) (bool, error)
+
+	// Do read unlock for given LockArgs. It should return
+	// * a boolean to indicate success/failure of the operation
+	// * an error on failure of unlock request operation.
+	RUnlock(args LockArgs) (bool, error)
+
+	// Do write unlock for given LockArgs. It should return
+	// * a boolean to indicate success/failure of the operation
+	// * an error on failure of unlock request operation.
+	Unlock(args LockArgs) (bool, error)
+
+	// Unlock (read/write) forcefully for given LockArgs. It should return
+	// * a boolean to indicate success/failure of the operation
+	// * an error on failure of unlock request operation.
+	ForceUnlock(args LockArgs) (bool, error)
+
+	// Return this lock server address.
 	ServerAddr() string
-	Resource() string
+
+	// Return this lock server service endpoint on which the server runs.
+	ServiceEndpoint() string
 }


### PR DESCRIPTION
Previously dsync was using more specific to minio server code base.
This patch makes dsync as generic distrbuted sync.mutex package.