### PR TITLE
tests: netlocker should retry automatically upon `rpc.ErrShutdown`

### DIFF
--- a/chaos/net-rpc-client.go
+++ b/chaos/net-rpc-client.go
@@ -17,7 +17,6 @@
 package main
 
 import (
-	"errors"
 	"net/rpc"
 	"sync"
 
@@ -26,86 +25,58 @@ import (
 
 // ReconnectRPCClient is a wrapper type for rpc.Client which provides reconnect on first failure.
 type ReconnectRPCClient struct {
-	mu         sync.Mutex
-	rpcPrivate *rpc.Client
-	node       string
-	rpcPath    string
+	mutex    sync.Mutex
+	rpc      *rpc.Client
+	addr     string
+	endpoint string
 }
 
-// newClient constructs a ReconnectRPCClient object with node and rpcPath initialized.
+// newClient constructs a ReconnectRPCClient object with addr and endpoint initialized.
 // It _doesn't_ connect to the remote endpoint. See Call method to see when the
 // connect happens.
-func newClient(node, rpcPath string) *ReconnectRPCClient {
+func newClient(addr, endpoint string) *ReconnectRPCClient {
 	return &ReconnectRPCClient{
-		node:    node,
-		rpcPath: rpcPath,
+		addr:     addr,
+		endpoint: endpoint,
 	}
 }
 
-// clearRPCClient clears the pointer to the rpc.Client object in a safe manner
-func (rpcClient *ReconnectRPCClient) clearRPCClient() {
-	rpcClient.mu.Lock()
-	rpcClient.rpcPrivate = nil
-	rpcClient.mu.Unlock()
-}
-
-// getRPCClient gets the pointer to the rpc.Client object in a safe manner
-func (rpcClient *ReconnectRPCClient) getRPCClient() *rpc.Client {
-	rpcClient.mu.Lock()
-	rpcLocalStack := rpcClient.rpcPrivate
-	rpcClient.mu.Unlock()
-	return rpcLocalStack
-}
-
-// dialRPCClient tries to establish a connection to the server in a safe manner
-func (rpcClient *ReconnectRPCClient) dialRPCClient() (*rpc.Client, error) {
-	rpcClient.mu.Lock()
-	defer rpcClient.mu.Unlock()
-	// After acquiring lock, check whether another thread may not have already dialed and established connection
-	if rpcClient.rpcPrivate != nil {
-		return rpcClient.rpcPrivate, nil
+// Close closes the underlying socket file descriptor.
+func (rpcClient *ReconnectRPCClient) Close() error {
+	rpcClient.mutex.Lock()
+	defer rpcClient.mutex.Unlock()
+	// If rpc client has not connected yet there is nothing to close.
+	if rpcClient.rpc == nil {
+		return nil
 	}
-	rpc, err := rpc.DialHTTPPath("tcp", rpcClient.node, rpcClient.rpcPath)
-	if err != nil {
-		return nil, err
-	} else if rpc == nil {
-		return nil, errors.New("No valid RPC Client created after dial")
-	}
-	rpcClient.rpcPrivate = rpc
-	return rpcClient.rpcPrivate, nil
+	// Reset rpcClient.rpc to allow for subsequent calls to use a new
+	// (socket) connection.
+	clnt := rpcClient.rpc
+	rpcClient.rpc = nil
+	return clnt.Close()
 }
 
 // Call makes a RPC call to the remote endpoint using the default codec, namely encoding/gob.
-func (rpcClient *ReconnectRPCClient) Call(serviceMethod string, args interface{}, reply interface{}) error {
-	// Make a copy below so that we can safely (continue to) work with the rpc.Client.
-	// Even in the case the two threads would simultaneously find that the connection is not initialised,
-	// they would both attempt to dial and only one of them would succeed in doing so.
-	rpcLocalStack := rpcClient.getRPCClient()
-
-	// If the rpc.Client is nil, we attempt to (re)connect with the remote endpoint.
-	if rpcLocalStack == nil {
-		var err error
-		rpcLocalStack, err = rpcClient.dialRPCClient()
-		if err != nil {
-			return err
+func (rpcClient *ReconnectRPCClient) Call(serviceMethod string, args interface{}, reply interface{}) (err error) {
+	rpcClient.mutex.Lock()
+	defer rpcClient.mutex.Unlock()
+	dialCall := func() error {
+		// If the rpc.Client is nil, we attempt to (re)connect with the remote endpoint.
+		if rpcClient.rpc == nil {
+			clnt, derr := rpc.DialHTTPPath("tcp", rpcClient.addr, rpcClient.endpoint)
+			if derr != nil {
+				return derr
+			}
+			rpcClient.rpc = clnt
 		}
+		// If the RPC fails due to a network-related error, then we reset
+		// rpc.Client for a subsequent reconnect.
+		return rpcClient.rpc.Call(serviceMethod, args, reply)
 	}
-
-	// If the RPC fails due to a network-related error, then we reset
-	// rpc.Client for a subsequent reconnect.
-	err := rpcLocalStack.Call(serviceMethod, args, reply)
-	if err != nil {
-		if err.Error() == rpc.ErrShutdown.Error() {
-			// Reset rpcClient.rpc to nil to trigger a reconnect in future
-			// and close the underlying connection.
-			rpcClient.clearRPCClient()
-
-			// Close the underlying connection.
-			rpcLocalStack.Close()
-
-			// Set rpc error as rpc.ErrShutdown type.
-			err = rpc.ErrShutdown
-		}
+	if err = dialCall(); err == rpc.ErrShutdown {
+		rpcClient.rpc.Close()
+		rpcClient.rpc = nil
+		err = dialCall()
 	}
 	return err
 }
@@ -135,26 +106,10 @@ func (rpcClient *ReconnectRPCClient) ForceUnlock(args dsync.LockArgs) (status bo
 	return status, err
 }
 
-// Close closes the underlying socket file descriptor.
-func (rpcClient *ReconnectRPCClient) Close() error {
-	// See comment above for making a copy on local stack
-	rpcLocalStack := rpcClient.getRPCClient()
-
-	// If rpc client has not connected yet there is nothing to close.
-	if rpcLocalStack == nil {
-		return nil
-	}
-
-	// Reset rpcClient.rpc to allow for subsequent calls to use a new
-	// (socket) connection.
-	rpcClient.clearRPCClient()
-	return rpcLocalStack.Close()
-}
-
 func (rpcClient *ReconnectRPCClient) ServerAddr() string {
-	return rpcClient.node
+	return rpcClient.addr
 }
 
 func (rpcClient *ReconnectRPCClient) ServiceEndpoint() string {
-	return rpcClient.rpcPath
+	return rpcClient.endpoint
 }

--- a/drwmutex.go
+++ b/drwmutex.go
@@ -381,12 +381,12 @@ func (dm *DRWMutex) ForceUnlock() {
 func sendRelease(c NetLocker, name, uid string, isReadLock bool) {
 
 	backOffArray := []time.Duration{
-		30 * time.Second, // 30secs.
-		1 * time.Minute,  // 1min.
-		3 * time.Minute,  // 3min.
-		10 * time.Minute, // 10min.
-		30 * time.Minute, // 30min.
-		1 * time.Hour,    // 1hr.
+		30 * time.Second, // 30 secs
+		1 * time.Minute,  // 1 min
+		3 * time.Minute,  // 3 min
+		10 * time.Minute, // 10 min
+		30 * time.Minute, // 30 min
+		1 * time.Hour,    // 1 hour
 	}
 
 	go func(c NetLocker, name string) {


### PR DESCRIPTION
This is implemented so that the Unlock,Lock() calls
can retry a disconnected rpc client connection in tests
and also use the terms uniformly across like node, rpcPath
are deprecated with the new interface.

