### PR TITLE
Add go-routine that monitors lock maintenance loop 

### DIFF
--- a/chaos/chaos-server.go
+++ b/chaos/chaos-server.go
@@ -63,19 +63,17 @@ func startRPCServer(port int) {
 	}
 	lockMonitor := func() {
 		lastHeartBeat := uint64(0)
-		lastHeartBeatStamp := time.Now()
+		lastHeartBeatStamp := time.Now().UTC()
 		for {
 			time.Sleep(LockMaintenanceLoop)
 			currentHeartBeat := atomic.LoadUint64(&lockHeartBeat)
 			if currentHeartBeat > lastHeartBeat {
 				lastHeartBeat = currentHeartBeat
 				lastHeartBeatStamp = time.Now()
-			}
-			// Check whether not too much time has passed since last 'sign' of life
-			// from maintenance loop
-			if time.Since(lastHeartBeatStamp) > LockMaintenanceHealthThreshold {
-				// reset state to initiate new monitoring
-				atomic.StoreUint64(&lockHeartBeat, 0)
+			} else if time.Now().UTC().Sub(lastHeartBeatStamp) > LockMaintenanceHealthThreshold {
+				// Too much time has passed since last 'sign' of life from maintenance loop
+
+				atomic.StoreUint64(&lockHeartBeat, 0) // Reset state to initiate new monitoring
 				lastHeartBeat = uint64(0)
 				lastHeartBeatStamp = time.Now()
 

--- a/chaos/chaos-server.go
+++ b/chaos/chaos-server.go
@@ -25,6 +25,7 @@ import (
 	"net/rpc"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -33,9 +34,11 @@ import (
 //
 // const LockMaintenanceLoop       = 1 * time.Minute
 // const LockCheckValidityInterval = 2 * time.Minute
+// const LockMaintenanceHealthThreshold = 5 * LockMaintenanceLoop
 //
 const LockMaintenanceLoop = 1 * time.Second
 const LockCheckValidityInterval = 5 * time.Second
+const LockMaintenanceHealthThreshold = 10 * LockMaintenanceLoop
 
 func startRPCServer(port int) {
 	log.SetPrefix(fmt.Sprintf("[%d] ", port))
@@ -47,14 +50,42 @@ func startRPCServer(port int) {
 		lockMap: make(map[string][]lockRequesterInfo),
 		// timestamp: leave uninitialized for testing (set to real timestamp for actual usage)
 	}
-	go func() {
+	lockHeartBeat := uint64(0)
+
+	lockMaintainer := func() {
 		// Start with random sleep time, so as to avoid "synchronous checks" between servers
 		time.Sleep(time.Duration(rand.Float64() * float64(LockMaintenanceLoop)))
 		for {
 			time.Sleep(LockMaintenanceLoop)
 			locker.lockMaintenance(LockCheckValidityInterval)
+			atomic.AddUint64(&lockHeartBeat, 1)
 		}
-	}()
+	}
+	lockMonitor := func() {
+		lastHeartBeat := uint64(0)
+		lastHeartBeatStamp := time.Now()
+		for {
+			time.Sleep(LockMaintenanceLoop)
+			currentHeartBeat := atomic.LoadUint64(&lockHeartBeat)
+			if currentHeartBeat > lastHeartBeat {
+				lastHeartBeat = currentHeartBeat
+				lastHeartBeatStamp = time.Now()
+			}
+			// Check whether not too much time has passed since last 'sign' of life
+			// from maintenance loop
+			if time.Since(lastHeartBeatStamp) > LockMaintenanceHealthThreshold {
+				// reset state to initiate new monitoring
+				atomic.StoreUint64(&lockHeartBeat, 0)
+				lastHeartBeat = uint64(0)
+				lastHeartBeatStamp = time.Now()
+
+				// restart maintainer
+				go lockMaintainer()
+			}
+		}
+	}
+	go lockMaintainer()
+	go lockMonitor()
 	server.RegisterName("Dsync", locker)
 	// For some reason the registration paths need to be different (even for different server objs)
 	rpcPath := rpcPathPrefix + "-" + strconv.Itoa(port)


### PR DESCRIPTION
And restarts it if it has become inactive for some time.

This has been tested manually and will restart the lockMaintenance loop just fine if it has stopped.

Just the `LockMaintenanceHealthThreshold` needs to be chosen appropriately, it should not undercut the time that one iteration of the lock maintenance loop can take.