### PR TITLE
Change dsync to support more client objects per instance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,18 +6,17 @@ os:
 
 env:
 - ARCH=x86_64
-- ARCH=i686
 
 go:
-- 1.6
-- 1.7.4
+- 1.8.x
+- 1.9.x
 
 script:
 - diff -au <(gofmt -d .) <(printf "")
 - go vet ./...
 - go get -u github.com/client9/misspell/cmd/misspell
-- misspell -error .
 - go get -u github.com/gordonklaus/ineffassign
+- misspell -error .
 - ineffassign .
 - go test -v
 - go test -v -race

--- a/README.md
+++ b/README.md
@@ -87,22 +87,26 @@ The system can be pushed to 75K locks/sec at 50% CPU load.
 Usage
 -----
 
+> NOTE: Previously if you were using `dsync.Init([]NetLocker, nodeIndex)` to initialize dsync has
+been changed to `dsync.New([]NetLocker, nodeIndex)` which returns a `*Dsync` object to be used in
+every instance of `NewDRWMutex("test", *Dsync)`
+
 ### Exclusive lock 
 
 Here is a simple example showing how to protect a single resource (drop-in replacement for `sync.Mutex`):
 
-```
+```go
 import (
-    "github.com/minio/dsync"
+	"github.com/minio/dsync"
 )
 
 func lockSameResource() {
 
-    // Create distributed mutex to protect resource 'test'
-	dm := dsync.NewDRWMutex("test")
+	// Create distributed mutex to protect resource 'test'
+	dm := dsync.NewDRWMutex("test", ds)
 
 	dm.Lock()
-    log.Println("first lock granted")
+	log.Println("first lock granted")
 
 	// Release 1st lock after 5 seconds
 	go func() {
@@ -111,10 +115,10 @@ func lockSameResource() {
 		dm.Unlock()
 	}()
 
-    // Try to acquire lock again, will block until initial lock is released
-    log.Println("about to lock same resource again...")
+	// Try to acquire lock again, will block until initial lock is released
+	log.Println("about to lock same resource again...")
 	dm.Lock()
-    log.Println("second lock granted")
+	log.Println("second lock granted")
 
 	time.Sleep(2 * time.Second)
 	dm.Unlock()
@@ -137,7 +141,7 @@ DRWMutex also supports multiple simultaneous read locks as shown below (analogou
 ```
 func twoReadLocksAndSingleWriteLock() {
 
-	drwm := dsync.NewDRWMutex("resource")
+	drwm := dsync.NewDRWMutex("resource", ds)
 
 	drwm.RLock()
 	log.Println("1st read lock acquired, waiting...")
@@ -160,7 +164,7 @@ func twoReadLocksAndSingleWriteLock() {
 	log.Println("Trying to acquire write lock, waiting...")
 	drwm.Lock()
 	log.Println("Write lock acquired, waiting...")
-	
+
 	time.Sleep(3 * time.Second)
 
 	drwm.Unlock()

--- a/dsync.go
+++ b/dsync.go
@@ -16,51 +16,52 @@
 
 package dsync
 
-import "errors"
+import (
+	"errors"
+)
 
-// Number of nodes participating in the distributed locking.
-var dnodeCount int
+// Dsync represents dsync client object which is initialized with
+// authenticated clients, used to initiate lock RPC calls.
+type Dsync struct {
+	// Number of nodes participating in the distributed locking.
+	dNodeCount int
 
-// List of rpc client objects, one per lock server.
-var clnts []NetLocker
+	// List of rpc client objects, one per lock server.
+	rpcClnts []NetLocker
 
-// Index into rpc client array for server running on localhost
-var ownNode int
+	// Index into rpc client array for server running on localhost
+	ownNode int
 
-// Simple majority based quorum, set to dNodeCount/2+1
-var dquorum int
+	// Simple majority based quorum, set to dNodeCount/2+1
+	dquorum int
 
-// Simple quorum for read operations, set to dNodeCount/2
-var dquorumReads int
+	// Simple quorum for read operations, set to dNodeCount/2
+	dquorumReads int
+}
 
-// Init - initializes package-level global state variables such as clnts.
-// N B - This function should be called only once inside any program
-// that uses dsync.
-func Init(rpcClnts []NetLocker, rpcOwnNode int) (err error) {
-
-	// Validate if number of nodes is within allowable range.
-	if dnodeCount != 0 {
-		return errors.New("Cannot reinitialize dsync package")
-	}
+// New - initializes a new dsync object with input rpcClnts.
+func New(rpcClnts []NetLocker, rpcOwnNode int) (*Dsync, error) {
 	if len(rpcClnts) < 4 {
-		return errors.New("Dsync is not designed for less than 4 nodes")
+		return nil, errors.New("Dsync is not designed for less than 4 nodes")
 	} else if len(rpcClnts) > 16 {
-		return errors.New("Dsync is not designed for more than 16 nodes")
+		return nil, errors.New("Dsync is not designed for more than 16 nodes")
 	} else if len(rpcClnts)%2 != 0 {
-		return errors.New("Dsync is not designed for an uneven number of nodes")
+		return nil, errors.New("Dsync is not designed for an uneven number of nodes")
 	}
 
 	if rpcOwnNode > len(rpcClnts) {
-		return errors.New("Index for own node is too large")
+		return nil, errors.New("Index for own node is too large")
 	}
 
-	dnodeCount = len(rpcClnts)
-	dquorum = dnodeCount/2 + 1
-	dquorumReads = dnodeCount / 2
-	// Initialize node name and rpc path for each NetLocker object.
-	clnts = make([]NetLocker, dnodeCount)
-	copy(clnts, rpcClnts)
+	ds := &Dsync{}
+	ds.dNodeCount = len(rpcClnts)
+	ds.dquorum = ds.dNodeCount/2 + 1
+	ds.dquorumReads = ds.dNodeCount / 2
+	ds.ownNode = rpcOwnNode
 
-	ownNode = rpcOwnNode
-	return nil
+	// Initialize node name and rpc path for each NetLocker object.
+	ds.rpcClnts = make([]NetLocker, ds.dNodeCount)
+	copy(ds.rpcClnts, rpcClnts)
+
+	return ds, nil
 }

--- a/examples/auth-locker/main.go
+++ b/examples/auth-locker/main.go
@@ -38,12 +38,13 @@ func main() {
 	}
 
 	// Initialize dsync and treat 0th index on lockClients as self node.
-	if err := dsync.Init(lockClients, 0); err != nil {
+	ds, err := dsync.New(lockClients, 0)
+	if err != nil {
 		log.Fatal("Fail to initialize dsync.", err)
 	}
 
 	// Get new distributed RWMutex on resource "Music"
-	drwMutex := dsync.NewDRWMutex("Music")
+	drwMutex := dsync.NewDRWMutex("Music", ds)
 
 	// Lock "music" resource.
 	drwMutex.Lock()


### PR DESCRIPTION
This is precursor change to support 16 > slots in erasure
coded set up under minio. The new style of slots handling
allows minio to expand the storage from 16 disks to
multiple of 16 disks allowing the namespace to scale to
beyond 16 disks.

Locking on the other hand in current style expects one
dsync instance per node, this assumption should be changed
to accomodate the new change of single server exporting
more than 16 disks.

Each slot will have its own dsync allowing objects to
be independently locked and accessed per slot. Since
object is hashed deterministically to a slot, each slot
holds its own locking.